### PR TITLE
Add web UI for Sentry rule building

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # sentry-issuegroup-build-validate
-An Issue Grouping Rule builder and validator for Sentry
+
+This repository contains a small static web application that helps you create and verify [Sentry](https://sentry.io) issue grouping rules. It provides two main tools:
+
+1. **Rule Builder** – interactively add matchers and expressions to compose a fingerprint rule. The builder outputs a valid rule string that you can copy into your Sentry project settings.
+2. **Rule Validator** – paste one or many fingerprint rules and the validator will highlight each line in green (valid), red (invalid) or yellow (potential improvements). Hover over a rule to see a short explanation or suggestion.
+
+The implementation is completely client‑side and requires no build step. Open `index.html` in a browser to use it.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,84 @@
+const matcherOptions = [
+  'error.type','error.value','message','logger','level',
+  'tags.tag','stack.abs_path','stack.module','stack.function','stack.package',
+  'family','app'
+];
+
+function addMatcherRow() {
+  const idx = document.querySelectorAll('.matcherRow').length;
+  const row = document.createElement('div');
+  row.className = 'matcherRow';
+  row.innerHTML = `<select class="matcher" data-idx="${idx}">
+    ${matcherOptions.map(m=>`<option value="${m}">${m}</option>`).join('')}
+  </select>
+  <input type="text" class="expression" placeholder="expression">`;
+  document.getElementById('matchers').appendChild(row);
+}
+
+document.getElementById('addMatcher').onclick = addMatcherRow;
+addMatcherRow();
+
+function buildRule(e) {
+  e.preventDefault();
+  const matchers = [];
+  document.querySelectorAll('.matcherRow').forEach(row => {
+    const m = row.querySelector('.matcher').value;
+    const exp = row.querySelector('.expression').value;
+    if(m && exp) matchers.push(`${m}:${exp}`);
+  });
+  const fingerprint = document.getElementById('fingerprint').value.trim();
+  const ruleName = document.getElementById('ruleName').value.trim();
+  let line = matchers.join(' ');
+  if(fingerprint) line += ` -> ${fingerprint}`;
+  if(ruleName) line = `# ${ruleName}\n` + line;
+  document.getElementById('builtRule').textContent = line;
+}
+
+document.getElementById('builderForm').addEventListener('submit', buildRule);
+
+const allowedMatchers = new Set([
+  'error.type','type','error.value','value','message','logger','level',
+  'stack.abs_path','path','stack.module','module','stack.function','function',
+  'stack.package','package','family','app'
+]);
+
+function validateRule(line) {
+  const result = {status:'valid', message:''};
+  line = line.trim();
+  if(!line || line.startsWith('#')) { result.status='comment'; return result; }
+  const parts = line.split('->');
+  if(parts.length!==2) { result.status='invalid'; result.message='Missing `->`'; return result; }
+  const [left,right] = parts.map(p=>p.trim());
+  const tokens = left.split(/\s+/);
+  for(const token of tokens) {
+    const [m,exp] = token.split(':');
+    if(!exp) { result.status='invalid'; result.message=`Missing expression for ${m}`; return result; }
+    if(!allowedMatchers.has(m.split('.')[0]+'-'+m.split('.')[1])){}
+  }
+  if(!right) { result.status='invalid'; result.message='Missing fingerprint'; return result; }
+  // Improvement: suggest default variable if not using it
+  if(!right.includes('{{ default }}')) {
+    result.status='improve';
+    result.message='Consider adding {{ default }} to refine existing grouping';
+  }
+  result.explanation = `Groups events where ${left} and assigns fingerprint ${right}`;
+  return result;
+}
+
+function runValidation() {
+  const input = document.getElementById('rulesInput').value.split(/\n+/);
+  const out = document.getElementById('validationOutput');
+  out.innerHTML='';
+  input.forEach((line,i)=>{
+    const res = validateRule(line);
+    if(res.status==='comment') return;
+    const div=document.createElement('div');
+    div.textContent=line;
+    if(res.status==='valid') div.className='valid';
+    else if(res.status==='invalid') div.className='invalid';
+    else div.className='improve';
+    div.title=res.status==='valid'?res.explanation:res.message;
+    out.appendChild(div);
+  });
+}
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Sentry Grouping Rule Builder & Validator</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h1>Sentry Grouping Rule Builder & Validator</h1>
+<div id="builder">
+<h2>Rule Builder</h2>
+<form id="builderForm">
+<div id="matchers"></div>
+<button type="button" id="addMatcher">Add Matcher</button>
+<div>
+<label>Rule Name/Type <input type="text" id="ruleName"></label>
+</div>
+<div>
+<label>Fingerprint / Variables <input type="text" id="fingerprint"></label>
+</div>
+<button type="submit">Build Rule</button>
+</form>
+<pre id="builtRule"></pre>
+</div>
+<hr>
+<div id="validator">
+<h2>Rule Validator</h2>
+<textarea id="rulesInput" rows="10" cols="80" placeholder="Paste fingerprint rules here, one per line"></textarea>
+<pre id="validationOutput"></pre>
+</div>
+<script src="app.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,8 @@
+body { font-family: Arial, sans-serif; margin: 20px; }
+h1 { text-align: center; }
+#builder, #validator { margin-bottom: 40px; }
+.matcherRow { margin-bottom: 5px; }
+.valid { background-color: #e0ffe0; }
+.invalid { background-color: #ffe0e0; }
+.improve { background-color: #fff5cc; }
+pre { background: #f6f8fa; padding: 10px; }


### PR DESCRIPTION
## Summary
- create static rule builder/validator web app
- style with simple CSS
- document usage in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6857b533d0488326b35a40a375b7f044