### PR TITLE
Enable Vercel deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,34 @@
 # sentry-issuegroup-build-validate
 
-This repository contains a small static web application that helps you create and verify [Sentry](https://sentry.io) issue grouping rules. It provides two main tools:
+This is a small web application that helps you compose and validate [Sentry](https://sentry.io) issue grouping rules. It can run locally using a Node.js server or be deployed as a static site with a serverless function on Vercel.
 
-1. **Rule Builder** – interactively add matchers and expressions to compose a fingerprint rule. The builder outputs a valid rule string that you can copy into your Sentry project settings.
-2. **Rule Validator** – paste one or many fingerprint rules and the validator will highlight each line in green (valid), red (invalid) or yellow (potential improvements). Hover over a rule to see a short explanation or suggestion.
+## Features
 
-The application is served via a small Node.js server that loads Sentry configuration
-from a `.env` file. The server also exposes a `config.js` endpoint consumed by the
-client to initialize Sentry.
+- **Rule Builder** – interactively add matchers and expressions to compose fingerprint rules. The built rule can be copied directly into your Sentry project settings.
+- **Rule Validator** – paste existing rules and instantly see whether they are valid, invalid or have potential improvements.
+- **Sentry Integration** – the client initializes Sentry for error monitoring, performance tracking, profiling and session replay using settings exposed by a small configuration endpoint.
 
 ## Running Locally
 
-1. Clone the repository and change into the directory:
+1. Clone the repository and install dependencies:
    ```bash
    git clone <repo-url>
    cd sentry-issuegroup-build-validate
-   ```
-2. Copy `.env.example` to `.env` and fill in your Sentry details.
-3. Install dependencies and start the Node.js server:
-   ```bash
    npm install
+   ```
+2. Create a `.env` file based on `.env.example` and provide the Sentry credentials for your project.
+3. Start the development server:
+   ```bash
    node server.js
    ```
 4. Open `http://localhost:3000` in your browser.
+
+## Deploying to Vercel
+
+1. [Install the Vercel CLI](https://vercel.com/docs/cli) and log in with `vercel login`.
+2. Run `vercel` in the project directory and follow the prompts to create a new project.
+3. In the Vercel dashboard or via `vercel env`, set the environment variables `SENTRY_ORG`, `SENTRY_PROJECT` and `SENTRY_DSN`.
+4. Deploy the site with `vercel --prod`.
+
+Vercel will automatically serve the static assets in the repository and run the `/api/config.js` function to expose your configuration to the client.
 

--- a/api/config.js
+++ b/api/config.js
@@ -1,0 +1,8 @@
+module.exports = (req, res) => {
+  res.setHeader('Content-Type', 'application/javascript');
+  res.end(
+    `window.SENTRY_ORG='${process.env.SENTRY_ORG}';\n` +
+    `window.SENTRY_PROJECT='${process.env.SENTRY_PROJECT}';\n` +
+    `window.SENTRY_DSN='${process.env.SENTRY_DSN}';`
+  );
+};

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <script src="https://browser.sentry-cdn.com/7.113.0/bundle.tracing.replay.min.js" crossorigin="anonymous"></script>
-<script src="config.js"></script>
+<script src="/api/config.js"></script>
 <h1>Sentry Grouping Rule Builder & Validator</h1>
 <div id="builder">
 <h2>Rule Builder</h2>

--- a/server.js
+++ b/server.js
@@ -20,9 +20,8 @@ Sentry.init({
 
 app.use(express.static(path.join(__dirname, '.')));
 
-app.get('/config.js', (req, res) => {
-  res.type('application/javascript').send(`window.SENTRY_ORG='${process.env.SENTRY_ORG}';\nwindow.SENTRY_PROJECT='${process.env.SENTRY_PROJECT}';\nwindow.SENTRY_DSN='${process.env.SENTRY_DSN}';`);
-});
+const configHandler = require('./api/config');
+app.get('/api/config.js', configHandler);
 
 app.use(Sentry.expressErrorHandler());
 


### PR DESCRIPTION
## Summary
- provide `/api/config.js` endpoint for Vercel
- update index.html to load config from the API route
- expose the same route from the local server
- document running locally and on Vercel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857beba7aac83269b6a40c7d7550c0c