### PR TITLE
Add Sentry inspired frontend style

### DIFF
--- a/app.js
+++ b/app.js
@@ -118,3 +118,17 @@ function runValidation() {
   span.finish();
 }
 
+// theme toggle
+const savedTheme = localStorage.getItem('theme') || 'light';
+document.body.dataset.theme = savedTheme;
+const themeToggleBtn = document.getElementById('themeToggle');
+if (themeToggleBtn) {
+  themeToggleBtn.textContent = savedTheme === 'dark' ? '☀️' : '🌙';
+  themeToggleBtn.addEventListener('click', () => {
+    const newTheme = document.body.dataset.theme === 'dark' ? 'light' : 'dark';
+    document.body.dataset.theme = newTheme;
+    themeToggleBtn.textContent = newTheme === 'dark' ? '☀️' : '🌙';
+    localStorage.setItem('theme', newTheme);
+  });
+}
+

--- a/index.html
+++ b/index.html
@@ -1,34 +1,39 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="UTF-8">
-<title>Sentry Grouping Rule Builder & Validator</title>
-<link rel="stylesheet" href="style.css">
+  <meta charset="UTF-8">
+  <title>Sentry Grouping Rule Builder & Validator</title>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
 <script src="https://browser.sentry-cdn.com/7.113.0/bundle.tracing.replay.min.js" crossorigin="anonymous"></script>
 <script src="/api/config.js"></script>
-<h1>Sentry Grouping Rule Builder & Validator</h1>
-<div id="builder">
-<h2>Rule Builder</h2>
-<form id="builderForm">
-<div id="matchers"></div>
-<button type="button" id="addMatcher">Add Matcher</button>
-<div>
-<label>Rule Name/Type <input type="text" id="ruleName"></label>
-</div>
-<div>
-<label>Fingerprint / Variables <input type="text" id="fingerprint"></label>
-</div>
-<button type="submit">Build Rule</button>
-</form>
-<pre id="builtRule"></pre>
-</div>
-<hr>
-<div id="validator">
-<h2>Rule Validator</h2>
-<textarea id="rulesInput" rows="10" cols="80" placeholder="Paste fingerprint rules here, one per line"></textarea>
-<pre id="validationOutput"></pre>
+<header>
+  <h1>Sentry Grouping Rule Builder &amp; Validator</h1>
+  <button id="themeToggle" class="theme-toggle" aria-label="Toggle dark mode">🌙</button>
+</header>
+<div class="container">
+  <div id="builder">
+    <h2>Rule Builder</h2>
+    <form id="builderForm">
+      <div id="matchers"></div>
+      <button type="button" id="addMatcher">Add Matcher</button>
+      <div>
+        <label>Rule Name/Type <input type="text" id="ruleName"></label>
+      </div>
+      <div>
+        <label>Fingerprint / Variables <input type="text" id="fingerprint"></label>
+      </div>
+      <button type="submit">Build Rule</button>
+    </form>
+    <pre id="builtRule"></pre>
+  </div>
+  <hr>
+  <div id="validator">
+    <h2>Rule Validator</h2>
+    <textarea id="rulesInput" rows="10" cols="80" placeholder="Paste fingerprint rules here, one per line"></textarea>
+    <pre id="validationOutput"></pre>
+  </div>
 </div>
 <script src="app.js" defer></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -1,8 +1,106 @@
-body { font-family: Arial, sans-serif; margin: 20px; }
-h1 { text-align: center; }
-#builder, #validator { margin-bottom: 40px; }
-.matcherRow { margin-bottom: 5px; }
-.valid { background-color: #e0ffe0; }
-.invalid { background-color: #ffe0e0; }
-.improve { background-color: #fff5cc; }
-pre { background: #f6f8fa; padding: 10px; }
+:root {
+  --purple: #5c2d91;
+  --purple-dark: #4e29a2;
+  --bg: #f4f2ff;
+  --text: #2f2936;
+  --pre-bg: #fff;
+  --pre-border: #ece7ff;
+  --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+}
+
+[data-theme="dark"] {
+  --bg: #1f1b24;
+  --text: #f3f3f3;
+  --pre-bg: #2a2633;
+  --pre-border: #444;
+}
+
+body {
+  font-family: var(--font-family);
+  background: var(--bg);
+  color: var(--text);
+  margin: 0;
+}
+
+header {
+  position: relative;
+  background: var(--purple);
+  color: #fff;
+  padding: 20px;
+  text-align: center;
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+h1 {
+  margin: 0;
+}
+
+#builder,
+#validator {
+  margin-bottom: 40px;
+}
+
+.matcherRow {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 5px;
+}
+
+select,
+input,
+textarea {
+  padding: 6px 8px;
+  border: 1px solid #d0cce7;
+  border-radius: 4px;
+  font: inherit;
+}
+
+button {
+  background: var(--purple);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 8px 12px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+button:hover {
+  background: var(--purple-dark);
+}
+
+.theme-toggle {
+  position: absolute;
+  right: 10px;
+  top: 10px;
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 1.2em;
+  cursor: pointer;
+}
+
+.valid {
+  background-color: #e7f6e7;
+}
+
+.invalid {
+  background-color: #ffe5e5;
+}
+
+.improve {
+  background-color: #fff5cc;
+}
+
+pre {
+  background: var(--pre-bg);
+  padding: 10px;
+  border-radius: 4px;
+  border: 1px solid var(--pre-border);
+  overflow-x: auto;
+}


### PR DESCRIPTION
## Summary
- revamp index layout with header and container
- add Sentry-inspired color palette and button styling
- add dark mode with minimal toggle

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857c48c2f50832699a87b2615e52c7f